### PR TITLE
feat(nx-cloud): setup nx workspace

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -3,7 +3,8 @@
   "tasksRunnerOptions": {
     "default": {
       "runner": "nx-cloud",
-      "options": {
+      "      "accessToken": "YTc5ZTkxZGItMzJhMS00MDVjLWJmYWMtMjA2YTI4ZTAwNmY3fHJlYWQtd3JpdGU=",
+    options": {
         "cacheableOperations": ["build", "lint", "test", "e2e"],
         "url": "https://staging.nx.app"
       }


### PR DESCRIPTION
feat(nx-cloud): setup nx cloud workspace 

This commit set up Nx Cloud for your Nx workspace enabling distributed caching
and GitHub integration for fast CI and improved Developer Experience.
You can access your Nx Cloud workspace by going to 
http://localhost:4202/orgs/65bbb89a7e175af1866a652c/workspaces/65dd198280ef0c7802e0c362