### PR TITLE
feat(nx-cloud): setup nx workspace

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -1,26 +1,61 @@
 {
+
   "$schema": "./node_modules/nx/schemas/nx-schema.json",
+
   "tasksRunnerOptions": {
+
     "default": {
+
       "runner": "nx-cloud",
+
       "options": {
-        "cacheableOperations": ["build", "lint", "test", "e2e"],
-        "url": "https://staging.nx.app"
+
+        "cacheableOperations": [
+          "build",
+          "lint",
+          "test",
+          "e2e"
+        ],
+
+        "url": "https://staging.nx.app",
+
+        "accessToken": "ODQyNmIyZjEtZDBhYS00NDkwLTliN2YtNjY4ZmI2Nzk4MWRmfHJlYWQtd3JpdGU="
       }
     }
   },
+
   "targetDefaults": {
+
     "build": {
-      "dependsOn": ["^build"],
-      "inputs": ["production", "^production"]
+
+      "dependsOn": [
+        "^build"
+      ],
+
+      "inputs": [
+        "production",
+        "^production"
+      ]
     },
+
     "test": {
-      "inputs": ["default", "^production"]
+
+      "inputs": [
+        "default",
+        "^production"
+      ]
     },
+
     "e2e": {
-      "inputs": ["default", "^production"]
+
+      "inputs": [
+        "default",
+        "^production"
+      ]
     },
+
     "lint": {
+
       "inputs": [
         "default",
         "{workspaceRoot}/.eslintrc.json",
@@ -28,14 +63,21 @@
       ]
     }
   },
+
   "namedInputs": {
-    "default": ["{projectRoot}/**/*", "sharedGlobals"],
-    "production": [
+
+    "default": [
+      "{projectRoot}/**/*",
+      "sharedGlobals"
+    ],
+
+      "production": [
       "default",
       "!{projectRoot}/**/?(*.)+(spec|test).[jt]s?(x)?(.snap)",
       "!{projectRoot}/tsconfig.spec.json",
       "!{projectRoot}/.eslintrc.json"
     ],
-    "sharedGlobals": []
+
+      "sharedGlobals": []
   }
 }


### PR DESCRIPTION
feat(nx-cloud): setup nx cloud workspace 

This commit set up Nx Cloud for your Nx workspace enabling distributed caching
and GitHub integration for fast CI and improved Developer Experience.
You can access your Nx Cloud workspace by going to 
http://localhost:4202/orgs/65ddfe3b9d597543553c2a7e/workspaces/65ddfe8b80ef0c7802e0c374