### PR TITLE
feat(nx-cloud): setup nx workspace

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -6,7 +6,8 @@
       "options": {
         "cacheableOperations": ["build", "lint", "test", "e2e"],
         "url": "https://staging.nx.app"
-      }
+        "accessToken": "YmZjNjIxYWUtNTRiMS00ZjYyLWE3MzQtNDdlNGZiY2UwMzNmfHJlYWQtd3JpdGU=",
+}
     }
   },
   "targetDefaults": {


### PR DESCRIPTION
feat(nx-cloud): setup nx cloud workspace 

This commit set up Nx Cloud for your Nx workspace enabling distributed caching
and GitHub integration for fast CI and improved Developer Experience.
You can access your Nx Cloud workspace by going to 
http://localhost:4202/orgs/65ddfe3b9d597543553c2a7e/workspaces/65ddfffc80ef0c7802e0c378