### PR TITLE
feat(nx-cloud): setup nx workspace

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -1,6 +1,12 @@
 {
   "$schema": "./node_modules/nx/schemas/nx-schema.json",
   "tasksRunnerOptions": {
+  "default": {
+    "options": {
+      "accessToken": "ZTc1Mjg1NWEtYTJiMy00MDBjLTkwZDEtM2M2ZjdiNzZiNmI0fHJlYWQtd3JpdGU=",
+    }
+  }
+
     "default": {
       "runner": "nx-cloud",
       "options": {


### PR DESCRIPTION
feat(nx-cloud): setup nx cloud workspace 

This commit set up Nx Cloud for your Nx workspace enabling distributed caching
and GitHub integration for fast CI and improved Developer Experience.
You can access your Nx Cloud workspace by going to 
http://localhost:4202/orgs/65ddfe3b9d597543553c2a7e/workspaces/65de026880ef0c7802e0c37e