### PR TITLE
feat(nx-cloud): setup nx workspace

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -4,6 +4,9 @@
     "default": {
       "runner": "nx-cloud",
       "options": {
+        "accessToken": "NmYzMDhjMDYtN2JiYi00NDE2LWIwNWEtMzAwNWNmOWZlYzQzfHJlYWQtd3JpdGU=",
+
+        
         "cacheableOperations": ["build", "lint", "test", "e2e"],
         "url": "https://staging.nx.app"
       }


### PR DESCRIPTION
feat(nx-cloud): setup nx cloud workspace 

This commit set up Nx Cloud for your Nx workspace enabling distributed caching
and GitHub integration for fast CI and improved Developer Experience.
You can access your Nx Cloud workspace by going to 
http://localhost:4202/orgs/65ddfe3b9d597543553c2a7e/workspaces/65de04d780ef0c7802e0c384