### PR TITLE
feat(nx-cloud): setup nx workspace

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -1,4 +1,11 @@
 {
+  "tasksRunnerOptions": {
+    "default": {
+      "options": {
+        "accessToken": "ZWNmNzM0ZDItMDA2Zi00NmE1LTk3ZmYtNjViNDhjNTgzMzZkfHJlYWQtd3JpdGU="
+      }
+    }
+  },
   "$schema": "./node_modules/nx/schemas/nx-schema.json",
   "targetDefaults": {
     "build": {


### PR DESCRIPTION
feat(nx-cloud): setup nx cloud workspace 

This commit set up Nx Cloud for your Nx workspace enabling distributed caching
and GitHub integration for fast CI and improved Developer Experience.
You can access your Nx Cloud workspace by going to 
http://localhost:4202/orgs/65ddfe3b9d597543553c2a7e/workspaces/65e0a0d1f87e5428d0604c2f