### PR TITLE
feat(nx-cloud): setup nx workspace

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -32,6 +32,7 @@
   "tasksRunnerOptions": {
     "default": {
       "options": {
+        "accessToken": "OTkyNzE5ZGQtMjhkYS00ZWJlLTkxNjAtOGQ5MjQ0MjBlZTdhfHJlYWQtd3JpdGU=",
         "cacheableOperations": ["build", "lint", "test", "e2e"],
         "cacheableSet": true
       }


### PR DESCRIPTION
feat(nx-cloud): setup nx cloud workspace 

This commit set up Nx Cloud for your Nx workspace enabling distributed caching
and GitHub integration for fast CI and improved Developer Experience.
You can access your Nx Cloud workspace by going to 
http://localhost:4202/orgs/65ddfe3b9d597543553c2a7e/workspaces/65e0b0f2f87e5428d0604c45