### PR TITLE
feat(nx-cloud): setup nx workspace

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -5,12 +5,8 @@
       "dependsOn": ["^build"],
       "inputs": ["production", "^production"]
     },
-    "test": {
-      "inputs": ["default", "^production"]
-    },
-    "e2e": {
-      "inputs": ["default", "^production"]
-    },
+    "test": { "inputs": ["default", "^production"] },
+    "e2e": { "inputs": ["default", "^production"] },
     "lint": {
       "inputs": [
         "default",
@@ -29,5 +25,6 @@
     ],
     "sharedGlobals": []
   },
-  "nxCloudAccessToken": "YTdhZDYzYzEtNGI1My00M2Y5LTk4OWEtZDc1NjI4MzFlNzQ2fHJlYWQtd3JpdGU="
+  "nxCloudAccessToken": "MDBmODhjOWMtYzM5ZS00MzVhLTliMDktMjliOTVkODAyZDZmfHJlYWQtd3JpdGU=",
+  "nxCloudUrl": "http://localhost:4202"
 }


### PR DESCRIPTION
feat(nx-cloud): setup nx cloud workspace 

This commit set up Nx Cloud for your Nx workspace enabling distributed caching
and GitHub integration for fast CI and improved Developer Experience.

You can access your Nx Cloud workspace by going to 
http://localhost:4202/orgs/65ddfe3b9d597543553c2a7e/workspaces/65eb0b61b1387904b7fa8233

**Note:** This commit attempts to maintain formatting of the nx.json, however you may need to correct formatting by running an nx format command and committing the changes.