### PR TITLE
feat(nx-cloud): setup nx workspace

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -25,5 +25,6 @@
     ],
     "sharedGlobals": []
   },
-  "nxCloudUrl": "https://56d1-98-236-236-172.ngrok-free.app"
+  "nxCloudUrl": "http://localhost:4202",
+  "nxCloudAccessToken": "NjQzN2JlMWUtYTAzMy00YWEwLTg5ZTItMDI2MDQwNjc5OTc3fHJlYWQtd3JpdGU="
 }


### PR DESCRIPTION
feat(nx-cloud): setup nx cloud workspace 

This commit set up Nx Cloud for your Nx workspace enabling distributed caching
and GitHub integration for fast CI and improved Developer Experience.

You can access your Nx Cloud workspace by going to 
http://localhost:4202/orgs/660583ef23fe6859f47ff0a7/workspaces/663e7cf849c4c2118bc6391e

**Note:** This commit attempts to maintain formatting of the nx.json, however you may need to correct formatting by running an nx format command and committing the changes.